### PR TITLE
Fix scrolling

### DIFF
--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -8,6 +8,8 @@
   border-width: 1px 0;
   position: sticky;
   top: 0;
+  z-index: 10;
+  background-color: white;
 }
 
 .toolbarMenu {

--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -6,6 +6,8 @@
   align-items: center;
   display: flex;
   border-width: 1px 0;
+  position: sticky;
+  top: 0;
 }
 
 .toolbarMenu {

--- a/src/pages/Puzzle/Puzzle.scss
+++ b/src/pages/Puzzle/Puzzle.scss
@@ -4,7 +4,6 @@
 
 .puzzleContainer {
   height: 100%;
-  overflow: hidden;
 }
 
 .gameContainer {
@@ -21,6 +20,11 @@
 .currentClue {
   padding-bottom: 10px;
 
+}
+
+.gridContainer {
+  position: sticky;
+  top: 56;
 }
 
 .gridContainer,


### PR DESCRIPTION
These changes address issue #1 and fixes the ability to scroll by removing `overflow: auto` and adds `position: sticky` to the toolbar and grid containers so that they are always in view as you scroll through the clues list.